### PR TITLE
Include headers in request

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -53,6 +53,12 @@ func (t *Publisher) SendMessage(ctx context.Context, m *Message) (*PublishResp, 
 		return nil, err
 	}
 
+	for name, headers := range t.Headers {
+		for _, h := range headers {
+			req.Header.Set(name, h)
+		}
+	}
+
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thanks for making this package.

I self host my own ntfy server with basic auth in front. This requires me to set the `Authorization: Basic <base64-encoded-string>` header.

I was not able to get this working with `gotfy` as-is.

The `Publisher` struct exposes `Headers` which is great as I could set any headers for the request. Unfortunately, the `Headers` are not being referenced in `SendMessage`.

This PR adds support for including headers in the request.