### PR TITLE
Change the JSON ecoding to match what the ntfy server expects

### DIFF
--- a/http_action.go
+++ b/http_action.go
@@ -7,7 +7,7 @@ import (
 // HttpAction allows attaching an HTTP request action to a notification
 type HttpAction[X comparable] struct {
 	Label   string            `json:"label"`   //  string  -  Open garage door  Label of the action button in the notification
-	URL     string            `json:"url"`     //  string  -  https://ntfy.sh/mytopic  URL to which the HTTP request will be sent
+	URL     string            `json:"url,omitempty"`     //  string  -  https://ntfy.sh/mytopic  URL to which the HTTP request will be sent
 	Method  string            `json:"method"`  //  GET/POST/PUT/...  POST GET  HTTP method to use for request, default is POST ⚠️
 	Headers map[string]string `json:"headers"` // map of strings  -  see above  HTTP headers to pass in request. When publishing as JSON, headers are passed as a map. When the simple format is used, use headers.<header1>=<value>.
 	Body    X                 `json:"body"`    //  string  empty  some body, somebody?  HTTP body

--- a/http_action.go
+++ b/http_action.go
@@ -2,13 +2,12 @@ package gotfy
 
 import (
 	"encoding/json"
-	"net/url"
 )
 
 // HttpAction allows attaching an HTTP request action to a notification
 type HttpAction[X comparable] struct {
 	Label   string            `json:"label"`   //  string  -  Open garage door  Label of the action button in the notification
-	URL     *url.URL          `json:"url"`     //  string  -  https://ntfy.sh/mytopic  URL to which the HTTP request will be sent
+	URL     string            `json:"url"`     //  string  -  https://ntfy.sh/mytopic  URL to which the HTTP request will be sent
 	Method  string            `json:"method"`  //  GET/POST/PUT/...  POST GET  HTTP method to use for request, default is POST ⚠️
 	Headers map[string]string `json:"headers"` // map of strings  -  see above  HTTP headers to pass in request. When publishing as JSON, headers are passed as a map. When the simple format is used, use headers.<header1>=<value>.
 	Body    X                 `json:"body"`    //  string  empty  some body, somebody?  HTTP body

--- a/http_action_test.go
+++ b/http_action_test.go
@@ -1,17 +1,13 @@
 package gotfy
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHTTPActionMarshal(mainTest *testing.T) {
-	path, err := url.Parse("https://github.com/AnthonyHewins/gotfy")
-	if err != nil {
-		mainTest.Fatalf("failed setting up test var: %v", err)
-	}
+	path := "https://github.com/AnthonyHewins/gotfy"
 
 	testCases := []struct {
 		name        string
@@ -21,41 +17,41 @@ func TestHTTPActionMarshal(mainTest *testing.T) {
 	}{
 		{
 			name:     "base case",
-			expected: `{"action":"http","label":"","url":null}`,
+			expected: `{"action":"http","label":"","url":""}`,
 		},
 		{
 			name:     "label",
 			arg:      HttpAction[string]{Label: "label"},
-			expected: `{"action":"http","label":"label","url":null}`,
+			expected: `{"action":"http","label":"label","url":""}`,
 		},
 		{
 			name:     "url",
 			arg:      HttpAction[string]{URL: path},
-			expected: `{"action":"http","label":"","url":{"Scheme":"https","Opaque":"","User":null,"Host":"github.com","Path":"/AnthonyHewins/gotfy","RawPath":"","OmitHost":false,"ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""}}`,
+			expected: `{"action":"http","label":"","url":"https://github.com/AnthonyHewins/gotfy"}`,
 		},
 		{
 			name:     "method",
 			arg:      HttpAction[string]{Method: "method"},
-			expected: `{"action":"http","label":"","method":"method","url":null}`,
+			expected: `{"action":"http","label":"","method":"method","url":""}`,
 		},
 		{
 			name:     "headers",
 			arg:      HttpAction[string]{Headers: map[string]string{"header": "val"}},
-			expected: `{"action":"http","headers":{"header":"val"},"label":"","url":null}`,
+			expected: `{"action":"http","headers":{"header":"val"},"label":"","url":""}`,
 		},
 		{
 			name: "body",
 			arg: HttpAction[string]{
 				Body: "body",
 			},
-			expected: `{"action":"http","body":"IlwiYm9keVwiIg==","label":"","url":null}`,
+			expected: `{"action":"http","body":"IlwiYm9keVwiIg==","label":"","url":""}`,
 		},
 		{
 			name: "clear",
 			arg: HttpAction[string]{
 				Clear: true,
 			},
-			expected: `{"action":"http","clear":true,"label":"","url":null}`,
+			expected: `{"action":"http","clear":true,"label":"","url":""}`,
 		},
 		{
 			name: "everything",
@@ -67,7 +63,7 @@ func TestHTTPActionMarshal(mainTest *testing.T) {
 				Body:    "body",
 				Clear:   true,
 			},
-			expected: `{"action":"http","body":"IlwiYm9keVwiIg==","clear":true,"headers":{"header":"val"},"label":"label","method":"method","url":{"Scheme":"https","Opaque":"","User":null,"Host":"github.com","Path":"/AnthonyHewins/gotfy","RawPath":"","OmitHost":false,"ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""}}`,
+			expected: `{"action":"http","body":"IlwiYm9keVwiIg==","clear":true,"headers":{"header":"val"},"label":"label","method":"method","url":"https://github.com/AnthonyHewins/gotfy"}`,
 		},
 	}
 

--- a/message.go
+++ b/message.go
@@ -2,6 +2,7 @@ package gotfy
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // Message is a struct you can create from TopicPublisher that
@@ -16,7 +17,7 @@ type Message struct {
 	Actions  []ActionButton `json:"actions,omitempty"`  // Custom user action buttons for notifications
 	ClickURL string         `json:"click,omitempty"`    // Website opened when notification is clicked
 	IconURL  string         `json:"icon,omitempty"`     // URL to use as notification icon
-	Delay    interface{}    `json:"delay,omitempty"`    // Duration to delay delivery (string, int, whatever)
+	Delay    time.Duration  `json:"delay,omitempty"`    // Duration to delay delivery
 	Email    string         `json:"email,omitempty"`    // E-mail address for e-mail notifications
 	Call     string         `json:"call,omitempty"`     // Phone number to use for voice call
 
@@ -25,25 +26,43 @@ type Message struct {
 }
 
 func (m *Message) MarshalJSON() ([]byte, error) {
-	// if m.Priority <0, drop it
-	if m.Priority < 0 {
-		m.Priority = 0 // can't use nil, but this works
-	}
-	// if m.Delay is int and <=0, drop it
-	if i, ok := m.Delay.(int); ok && i <= 0 {
-		m.Delay = nil
+	type wire struct {
+		Topic    string         `json:"topic"`
+		Message  string         `json:"message,omitempty"`
+		Title    string         `json:"title,omitempty"`
+		Tags     []string       `json:"tags,omitempty"`
+		Priority Priority       `json:"priority,omitempty"`
+		Actions  []ActionButton `json:"actions,omitempty"`
+		ClickURL string         `json:"click,omitempty"`
+		IconURL  string         `json:"icon,omitempty"`
+		Delay    string         `json:"delay,omitempty"`
+		Email    string         `json:"email,omitempty"`
+		Call     string         `json:"call,omitempty"`
+
+		AttachURLFilename string `json:"filename,omitempty"`
+		AttachURL         string `json:"attachurl,omitempty"`
 	}
 
-	return json.Marshal(Message{
+	priority := m.Priority
+	if priority < 0 {
+		priority = 0
+	}
+
+	var delay string
+	if m.Delay > 0 {
+		delay = m.Delay.String()
+	}
+
+	return json.Marshal(wire{
 		Topic:    m.Topic,
 		Message:  m.Message,
 		Title:    m.Title,
 		Tags:     m.Tags,
-		Priority: m.Priority,
+		Priority: priority,
 		Actions:  m.Actions,
 		ClickURL: m.ClickURL,
 		IconURL:  m.IconURL,
-		Delay:    m.Delay,
+		Delay:    delay,
 		Email:    m.Email,
 		Call:     m.Call,
 

--- a/message_test.go
+++ b/message_test.go
@@ -3,7 +3,6 @@ package gotfy
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,24 +53,29 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 			name: "Actions",
 			arg: Message{Actions: []ActionButton{&ViewAction{
 				Label: "action",
-				Link:  &url.URL{Scheme: "http", Host: "host.com"},
+				Link:  "http://host.com",
 				Clear: true,
 			}}},
 			expected: `{"topic":"","actions":[{"action":"view","label":"action","url":"http://host.com","clear":true}]}`,
 		},
 		{
 			name:     "ClickURL",
-			arg:      Message{ClickURL: &url.URL{Scheme: "h", Host: "t.com"}},
+			arg:      Message{ClickURL: "h://t.com"},
 			expected: `{"topic":"","click":"h://t.com"}`,
 		},
 		{
 			name:     "IconURL",
-			arg:      Message{IconURL: &url.URL{Scheme: "h", Host: "t.com"}},
+			arg:      Message{IconURL: "h://t.com"},
 			expected: `{"topic":"","icon":"h://t.com"}`,
 		},
 		{
-			name:     "Delay",
+			name:     "Delay as int",
 			arg:      Message{Delay: 1},
+			expected: `{"topic":"","delay":1}`,
+		},
+		{
+			name:     "Delay as string",
+			arg:      Message{Delay: "1ns"},
 			expected: `{"topic":"","delay":"1ns"}`,
 		},
 		{
@@ -91,7 +95,7 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 		},
 		{
 			name:     "AttachURL",
-			arg:      Message{AttachURL: &url.URL{Scheme: "h", Host: "t.com"}},
+			arg:      Message{AttachURL: "h://t.com"},
 			expected: `{"topic":"","attachurl":"h://t.com"}`,
 		},
 		{
@@ -104,18 +108,18 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 				Priority: High,
 				Actions: []ActionButton{&ViewAction{
 					Label: "ajisdiopa",
-					Link:  &url.URL{Scheme: "h", Host: "t.com"},
+					Link:  "h://t.com",
 					Clear: true,
 				}},
-				ClickURL:          &url.URL{Scheme: "h", Host: "t.com"},
-				IconURL:           &url.URL{Scheme: "h", Host: "t.com"},
-				Delay:             100,
+				ClickURL:          "h://t.com",
+				IconURL:           "h://t.com",
+				Delay:             "10m",
 				Email:             "Email",
 				Call:              "Call",
 				AttachURLFilename: "AttachURLFilename",
-				AttachURL:         &url.URL{Scheme: "h", Host: "t.com"},
+				AttachURL:         "h://t.com",
 			},
-			expected: `{"topic":"Topic","message":"Message","title":"Title","tags":["tag1","tag2"],"priority":4,"actions":[{"action":"view","label":"ajisdiopa","url":"h://t.com","clear":true}],"click":"h://t.com","attachurl":"h://t.com","icon":"h://t.com","delay":"100ns","email":"Email","call":"Call","filename":"AttachURLFilename"}`,
+			expected: `{"topic":"Topic","message":"Message","title":"Title","tags":["tag1","tag2"],"priority":4,"actions":[{"action":"view","label":"ajisdiopa","url":"h://t.com","clear":true}],"click":"h://t.com","icon":"h://t.com","delay":"10m","email":"Email","call":"Call","filename":"AttachURLFilename","attachurl":"h://t.com"}`,
 		},
 		{
 			name: "test case failure 1/28/2024",
@@ -125,13 +129,13 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 				Tags:              []string{Nine},
 				Priority:          0,
 				Actions:           []ActionButton{},
-				ClickURL:          &url.URL{},
-				IconURL:           &url.URL{},
+				ClickURL:          "",
+				IconURL:           "",
 				Delay:             0,
 				Email:             "",
 				Call:              "",
 				AttachURLFilename: "",
-				AttachURL:         &url.URL{},
+				AttachURL:         "",
 				Message:           "ZSR: 9mm - ZSR Buffalo Cartridge 115 Grain Full Metal Jacket - 1000 Rounds 8683262441013 - FREE SHIPPING\n5.0/5 stars, 204 ratings",
 			},
 			expected: `{"topic":"9mm Luger brass 115 grain: $225.00/round, 1000 rounds","message":"ZSR: 9mm - ZSR Buffalo Cartridge 115 Grain Full Metal Jacket - 1000 Rounds 8683262441013 - FREE SHIPPING\n5.0/5 stars, 204 ratings","tags":["nine"]}`,

--- a/message_test.go
+++ b/message_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -69,13 +70,8 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 			expected: `{"topic":"","icon":"h://t.com"}`,
 		},
 		{
-			name:     "Delay as int",
-			arg:      Message{Delay: 1},
-			expected: `{"topic":"","delay":1}`,
-		},
-		{
-			name:     "Delay as string",
-			arg:      Message{Delay: "1ns"},
+			name:     "Delay as duration",
+			arg:      Message{Delay: time.Nanosecond},
 			expected: `{"topic":"","delay":"1ns"}`,
 		},
 		{
@@ -113,13 +109,13 @@ func TestMessageMarshalJSON(mainTest *testing.T) {
 				}},
 				ClickURL:          "h://t.com",
 				IconURL:           "h://t.com",
-				Delay:             "10m",
+				Delay:             10 * time.Minute,
 				Email:             "Email",
 				Call:              "Call",
 				AttachURLFilename: "AttachURLFilename",
 				AttachURL:         "h://t.com",
 			},
-			expected: `{"topic":"Topic","message":"Message","title":"Title","tags":["tag1","tag2"],"priority":4,"actions":[{"action":"view","label":"ajisdiopa","url":"h://t.com","clear":true}],"click":"h://t.com","icon":"h://t.com","delay":"10m","email":"Email","call":"Call","filename":"AttachURLFilename","attachurl":"h://t.com"}`,
+			expected: `{"topic":"Topic","message":"Message","title":"Title","tags":["tag1","tag2"],"priority":4,"actions":[{"action":"view","label":"ajisdiopa","url":"h://t.com","clear":true}],"click":"h://t.com","icon":"h://t.com","delay":"10m0s","email":"Email","call":"Call","filename":"AttachURLFilename","attachurl":"h://t.com"}`,
 		},
 		{
 			name: "test case failure 1/28/2024",

--- a/view_action.go
+++ b/view_action.go
@@ -2,12 +2,11 @@ package gotfy
 
 import (
 	"encoding/json"
-	"net/url"
 )
 
 type ViewAction struct {
 	Label string
-	Link  *url.URL
+	Link  string
 	Clear bool
 }
 
@@ -24,8 +23,8 @@ func (v *ViewAction) MarshalJSON() ([]byte, error) {
 	}
 	buf = append(buf, labelBuf...)
 
-	if v.Link != nil {
-		urlBuf, err := json.Marshal(v.Link.String())
+	if v.Link != "" {
+		urlBuf, err := json.Marshal(v.Link)
 		if err != nil {
 			return nil, err
 		}

--- a/view_action_test.go
+++ b/view_action_test.go
@@ -1,17 +1,13 @@
 package gotfy
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestViewMarshalJSON(mainTest *testing.T) {
-	uri, err := url.Parse("https://docs.ntfy.sh/publish/#icons")
-	if err != nil {
-		mainTest.Fatalf("failed setting up test URL: %v", err)
-	}
+	uri := "https://docs.ntfy.sh/publish/#icons"
 
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
As of now, many fields (URLs and time) aren't encoded correctly for `ntfy server v2.11.0`. Because of this, they just cause a 400 response and the message is not sent. 

This PR aims to correct that for 
- HTTP Actions' `URL` field: `string`
- View Actions' `URL` field: `string`
- `ClickURL`: `string`
- `IconURL`: `string`
- `AttachURL`: `string`
- `Delay`: either `int` (unix timestamp) or `string` (duration or [natural language] time string)


Additionally, I switched the `(m *Message) MarshalJSON() ([]byte], error)` to be a couple manual fixes (`m.Priority` and `m.Delay`) on top of `json.Marshal` to simplify the method. 

All tests have been updated, and I added one to test both `int`s and `strings` for `m.Delay`. 