### PR TITLE
implement authentication using the options pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,27 @@ go get github.com/AnthonyHewins/gotfy
 ## Example usage
 
 ```go
-server, _ := url.Parse("http://server.com")
-customHTTPClient := http.DefaultClient
+server, _ := url.Parse("https://server.com")
 
-tp, err := gotfy.NewPublisher(server, customHTTPClient)
+// Create a publisher with default HTTP client
+tp, err := gotfy.NewPublisher(server)
+if err != nil {
+    panic("bad config:"+err.Error())
+}
+
+// Or with custom HTTP client
+customHTTPClient := http.DefaultClient
+tp, err := gotfy.NewPublisher(server, gotfy.WithHTTPClient(customHTTPClient))
+
+// Or with basic authentication
+tp, err := gotfy.NewPublisher(server, gotfy.WithAuth("username", "password"))
+
+// Or combine multiple options
+tp, err := gotfy.NewPublisher(
+    server, 
+    gotfy.WithHTTPClient(customHTTPClient),
+    gotfy.WithAuth("username", "password"),
+)
 if err != nil {
     panic("bad config:"+err.Error())
 }

--- a/publisher.go
+++ b/publisher.go
@@ -3,6 +3,7 @@ package gotfy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,22 +25,43 @@ type Publisher struct {
 	Headers http.Header
 }
 
-// NewPublisher creates a topic publisher for the specified server URL,
-// and uses the supplied HTTP client to resolve the request
-func NewPublisher(server *url.URL, httpClient *http.Client) (*Publisher, error) {
+// Option is a functional option for configuring a Publisher
+type Option func(*Publisher)
+
+// WithHTTPClient sets a custom HTTP client for the publisher
+func WithHTTPClient(client *http.Client) Option {
+	return func(p *Publisher) {
+		p.httpClient = client
+	}
+}
+
+// WithAuth adds basic authentication to the publisher's headers
+func WithAuth(username, password string) Option {
+	return func(p *Publisher) {
+		auth := username + ":" + password
+		encoded := base64.StdEncoding.EncodeToString([]byte(auth))
+		p.Headers.Set("Authorization", "Basic "+encoded)
+	}
+}
+
+// NewPublisher creates a topic publisher for the specified server URL.
+// Options can be provided to customize the publisher behavior.
+func NewPublisher(server *url.URL, opts ...Option) (*Publisher, error) {
 	if server == nil {
 		return nil, ErrNoServer
 	}
 
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+	p := &Publisher{
+		server:     server,
+		httpClient: http.DefaultClient,
+		Headers:    http.Header{"Content-Type": []string{"application/json"}},
 	}
 
-	return &Publisher{
-		server:     server,
-		httpClient: httpClient,
-		Headers:    http.Header{"Content-Type": []string{"application/json"}},
-	}, nil
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p, nil
 }
 
 func (t *Publisher) SendMessage(ctx context.Context, m *Message) (*PublishResp, error) {

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,0 +1,228 @@
+package gotfy
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestWithAuth(t *testing.T) {
+	username := "testuser"
+	password := "testpass"
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	// Create a test server that checks for the Authorization header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != expectedAuth {
+			t.Errorf("Expected Authorization header %q, got %q", expectedAuth, auth)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Check Content-Type header is also present
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Expected Content-Type header %q, got %q", "application/json", contentType)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"test123","time":1234567890,"expires":1234567890,"event":"message"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	// Create publisher with authentication
+	publisher, err := NewPublisher(serverURL, WithAuth(username, password))
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+
+	// Send a test message
+	msg := &Message{
+		Topic:   "test-topic",
+		Message: "test message",
+	}
+
+	resp, err := publisher.SendMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	if resp.ID != "test123" {
+		t.Errorf("Expected response ID %q, got %q", "test123", resp.ID)
+	}
+}
+
+func TestWithAuthAndHTTPClient(t *testing.T) {
+	username := "testuser"
+	password := "testpass"
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != expectedAuth {
+			t.Errorf("Expected Authorization header %q, got %q", expectedAuth, auth)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"test456","time":1234567890,"expires":1234567890,"event":"message"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	// Create custom HTTP client
+	customClient := &http.Client{}
+
+	// Create publisher with both custom HTTP client and authentication
+	publisher, err := NewPublisher(
+		serverURL,
+		WithHTTPClient(customClient),
+		WithAuth(username, password),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+
+	// Verify the custom client was set
+	if publisher.httpClient != customClient {
+		t.Error("Expected custom HTTP client to be set")
+	}
+
+	// Send a test message
+	msg := &Message{
+		Topic:   "test-topic",
+		Message: "test message",
+	}
+
+	resp, err := publisher.SendMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	if resp.ID != "test456" {
+		t.Errorf("Expected response ID %q, got %q", "test456", resp.ID)
+	}
+}
+
+func TestWithoutAuth(t *testing.T) {
+	// Create a test server that should NOT receive an Authorization header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "" {
+			t.Errorf("Expected no Authorization header, got %q", auth)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"test789","time":1234567890,"expires":1234567890,"event":"message"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	// Create publisher without authentication
+	publisher, err := NewPublisher(serverURL)
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+
+	// Send a test message
+	msg := &Message{
+		Topic:   "test-topic",
+		Message: "test message",
+	}
+
+	resp, err := publisher.SendMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	if resp.ID != "test789" {
+		t.Errorf("Expected response ID %q, got %q", "test789", resp.ID)
+	}
+}
+
+func TestNewPublisher_NilServer(t *testing.T) {
+	_, err := NewPublisher(nil)
+	if err != ErrNoServer {
+		t.Errorf("Expected ErrNoServer, got %v", err)
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"test999","time":1234567890,"expires":1234567890,"event":"message"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	customClient := &http.Client{}
+
+	publisher, err := NewPublisher(serverURL, WithHTTPClient(customClient))
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+
+	if publisher.httpClient != customClient {
+		t.Error("Expected custom HTTP client to be set")
+	}
+
+	// Verify it works
+	msg := &Message{
+		Topic:   "test-topic",
+		Message: "test message",
+	}
+
+	resp, err := publisher.SendMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	if resp.ID != "test999" {
+		t.Errorf("Expected response ID %q, got %q", "test999", resp.ID)
+	}
+}
+
+func TestDefaultHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"default","time":1234567890,"expires":1234567890,"event":"message"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse server URL: %v", err)
+	}
+
+	publisher, err := NewPublisher(serverURL)
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+
+	if publisher.httpClient != http.DefaultClient {
+		t.Error("Expected default HTTP client to be set")
+	}
+}


### PR DESCRIPTION
it was not obvious for any user of this library to see how to send authenticated requests to the ntfy server. I initially implemented a custom http client with custom roundtripper when I discovered that the Header object was public in the publisher. A clearer and more idiomatic pattern is to use options to specify a custom http client and/or auth credentials. This is what is implemented here.